### PR TITLE
Add atomic for retries

### DIFF
--- a/taskiq_postgresql/abc/driver.py
+++ b/taskiq_postgresql/abc/driver.py
@@ -12,6 +12,7 @@ from taskiq_postgresql.abc.query import (
     CreateTableQuery,
     DeleteByDateQuery,
     DeleteQuery,
+    DeleteReturningQuery,
     InsertOrUpdateQuery,
     InsertQuery,
     SelectQuery,
@@ -49,6 +50,7 @@ class QueryDriver(ABC):
             self.table_name,
         )
         self.delete_query = DeleteQuery(self.table_name)
+        self.delete_returning_query = DeleteReturningQuery(self.table_name)
         self.delete_by_date_query = DeleteByDateQuery(self.table_name)
         self.select_query = SelectQuery(
             self.table_name,
@@ -100,6 +102,19 @@ class QueryDriver(ABC):
     @abstractmethod
     async def delete(self, column: Column, value: Any) -> Any:
         """Delete a row from a table."""
+
+    @abstractmethod
+    async def delete_returning(
+        self,
+        where_column: Column,
+        value: Any,
+        returning: Sequence[Column],
+    ) -> Optional[dict[str, Any]]:
+        """Atomically delete a row and return requested columns.
+
+        Returns a dictionary mapping column names to values for the deleted row,
+        or None if no row matched (e.g., already claimed by another worker).
+        """
 
     @abstractmethod
     async def delete_by_date(

--- a/taskiq_postgresql/abc/query.py
+++ b/taskiq_postgresql/abc/query.py
@@ -164,6 +164,22 @@ class DeleteQuery(QueryBase):
         return f"DELETE FROM {self.table_name} WHERE {column.name} = $1"  # noqa: S608
 
 
+class DeleteReturningQuery(QueryBase):
+    """Query to delete a row from a table and return specified columns."""
+
+    def __init__(self, table_name: str) -> None:
+        """Initialize the query."""
+        super().__init__(table_name)
+
+    def make_query(self, where_column: Column, returning: Sequence[Column]) -> str:
+        """Return the query as a string."""
+        return (
+            f"DELETE FROM {self.table_name} "  # noqa: S608
+            f"WHERE {where_column.name} = $1 "
+            f"RETURNING {', '.join(column.name for column in returning)}"
+        )
+
+
 class DeleteByDateQuery(QueryBase):
     """Query to delete a row from a table by date."""
 

--- a/taskiq_postgresql/drivers/_asyncpg.py
+++ b/taskiq_postgresql/drivers/_asyncpg.py
@@ -164,6 +164,22 @@ class AsyncpgDriver(QueryDriver):
                 value,
             )
 
+    async def delete_returning(
+        self,
+        where_column: Column,
+        value: Any,
+        returning: Sequence[Column],
+    ) -> Optional[dict[str, Any]]:
+        """Atomically delete a row and return requested columns."""
+        async with self, self.connection() as connection:
+            row = await connection.fetchrow(
+                self.delete_returning_query.make_query(where_column, returning),
+                value,
+            )
+            if row is None:
+                return None
+            return {column.name: row[column.name] for column in returning}
+
     async def select(
         self,
         columns: Sequence[Column],

--- a/uv.lock
+++ b/uv.lock
@@ -1762,7 +1762,7 @@ wheels = [
 
 [[package]]
 name = "taskiq-postgresql"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "taskiq" },


### PR DESCRIPTION
## Description

Fixes duplicate task execution when multiple workers are listening on the same channel and retries are enabled.
#7 
## Type of Change

- [ x ] 🐛 Bug fix (non-breaking change which fixes an issue)


## Changes Made

•  Atomically claim messages using a single DELETE ... RETURNING statement. Only one worker can delete+retrieve the payload; others get no row and skip.
•  ack() becomes a no-op (row is already deleted at claim time).
•  Normalize NOTIFY payloads to integers to handle drivers that deliver payloads as strings (e.g., psycopg).
Add DeleteReturningQuery (builds DELETE ... RETURNING SQL).
Extend QueryDriver with delete_returning(where_column, value, returning).
Implement delete_returning in all drivers:
•  asyncpg: fetchrow + map returning columns.
•  psycopg: dict_row + fetchone.
•  psqlpy: fetch + result()[0].
Update PostgresqlBroker.listen to atomically claim rows via delete_returning and make ack a no-op.
Normalize NOTIFY payload to int in broker.listen (handles string payloads).


### Test Configuration

•  Python version(s): 3.10 / 3.11 / 3.12
•  PostgreSQL version: 14 / 15 / 16
•  Driver(s) tested: asyncpg / psycopg / psqlpy
•  Operating System: Linux

## Performance Impact

- [ x ] No performance impact
- [ ] Positive performance impact
- [ ] Negative performance impact (please describe)

## Related Issues

Closes #7

